### PR TITLE
Force Werkzeug 2.0.0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,7 +47,7 @@ function install_pips {
 	declare -A pips=( ["Requests"]="requests>=2.26.0" ["Pillow"]="pillow==8.4.0" ["Telebot"]="--upgrade pyTelegramBotAPI" ["Dateutil"]="python-dateutil" ["ConfigParser"]="configparser>=5.0.0"\
 				  ["Google components"]="--upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib"\
 				  ["SPI Libs"]="spidev==3.5" ["Pandas"]="pandas==1.2.0 numpy==1.20" ["Flask"]="flask>=2.0.2" ["Flask-WTF"]="flask-wtf==1.0.0" \
-				  ["Flask-Login"]="flask-login==0.5.0" ["WTForms"]="wtforms>=3.0.0")
+				  ["Flask-Login"]="flask-login==0.5.0" ["WTForms"]="wtforms>=3.0.0" ["Werkzeug"]="werkzeug~=2.0.0")
 	for pip in "${!pips[@]}"; do
 		printf '\e[1;37m%-30s\e[m' "Installing $pip:"
 		if [ "$pip" == "Google components" ] || [ "$pip" == "Pandas" ] || [ "$pip" == "Telebot" ]; then 


### PR DESCRIPTION
Not sure if this is a suitable final solution but this should force Werkzeug 2.0.0 to be installed after Flask install and overwrite the 2.1.0 version used in Flask install.